### PR TITLE
docs: fix typo

### DIFF
--- a/docs/src/content/docs/guides/under-the-hood.md
+++ b/docs/src/content/docs/guides/under-the-hood.md
@@ -11,7 +11,7 @@ Load the emulator and the ROM.
 Nostalgist.js itself doesn't contain any emulators, but it has a resonable default options, so official emulators built with Emscripten and provided by [RetroArch's buildbot](https://buildbot.libretro.com/). It can also load some homebrew games from
 [retrobrews](https://retrobrews.github.io/) project without additional configuration.
 
-By default, cores will be loaded via [fetch](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) from [retroarch-emscripten-build](https://github.com/arianrhodsandlot/retroarch-emscripten-build) through [jsDelivr](https://www.jsdelivr.com). Fore example, the fceumm core, an NES emulator, will be loaded from these URLs:
+By default, cores will be loaded via [fetch](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) from [retroarch-emscripten-build](https://github.com/arianrhodsandlot/retroarch-emscripten-build) through [jsDelivr](https://www.jsdelivr.com). For example, the fceumm core, an NES emulator, will be loaded from these URLs:
 + https://cdn.jsdelivr.net/gh/arianrhodsandlot/retroarch-emscripten-build@v1.16.0/retroarch/fceumm_libretro.js
 + https://cdn.jsdelivr.net/gh/arianrhodsandlot/retroarch-emscripten-build@v1.16.0/retroarch/fceumm_libretro.wasm
 


### PR DESCRIPTION
fore example -> for example