### PR TITLE
fix: typo

### DIFF
--- a/src/types/retroarch-config/index.ts
+++ b/src/types/retroarch-config/index.ts
@@ -17,7 +17,6 @@ interface RetroArchFullConfig
     RetroArchRewindConfig,
     RetroArchRunAheadConfig,
     RetroArchSaveConfig,
-    RetroArchSkeletonConfig,
     RetroArchThemeConfig,
     RetroArchVideoConfig,
     RetroArchSkeletonConfig {


### PR DESCRIPTION
duplicated `RetroArchSkeletonConfig`