### PR TITLE
docs: fix jsdoc

### DIFF
--- a/src/nostalgist.ts
+++ b/src/nostalgist.ts
@@ -195,7 +195,7 @@ export class Nostalgist {
    * const nostalgist = await Nostalgist.nes('flappybird.nes')
    *
    * // save the state
-   * const { state } = await nostalgist.saveState(state)
+   * const { state } = await nostalgist.saveState()
    *
    * // load the state
    * await nostalgist.loadState(state)


### PR DESCRIPTION
There seems to be no arguments in `nostalgist.saveState()`.