### PR TITLE
fix: Added the "Blob" type to the "rom" argument of the "launch" meth…

### DIFF
--- a/docs/src/content/docs/apis/launch.md
+++ b/docs/src/content/docs/apis/launch.md
@@ -103,7 +103,7 @@ const nostalgist = await Nostalgist.launch({
 
   + #### `rom`
 
-    **type:** `string | File | { fileName: string; fileContent: Blob } | Array`
+    **type:** `string | File | { fileName: string; fileContent: Blob } | Array | Blob`
 
     The game ROM file.
 

--- a/docs/src/content/docs/apis/launch.md
+++ b/docs/src/content/docs/apis/launch.md
@@ -103,7 +103,7 @@ const nostalgist = await Nostalgist.launch({
 
   + #### `rom`
 
-    **type:** `string | File | { fileName: string; fileContent: Blob } | Array | Blob`
+    **type:** `string | Blob | { fileName: string; fileContent: Blob } | Array`
 
     The game ROM file.
 

--- a/src/nostalgist.ts
+++ b/src/nostalgist.ts
@@ -140,7 +140,7 @@ export class Nostalgist {
 
   private static async launchSystem(system: string, options: NostalgistLaunchRomOptions | NostalgistOptionsFile) {
     const launchOptions =
-      typeof options === 'string' || options instanceof File || ('fileName' in options && 'fileContent' in options)
+      typeof options === 'string' || options instanceof Blob || ('fileName' in options && 'fileContent' in options)
         ? { rom: options }
         : options
     const core = Nostalgist.getCoreForSystem(system)

--- a/src/types/nostalgist-options.ts
+++ b/src/types/nostalgist-options.ts
@@ -4,7 +4,7 @@ import type { RetroArchEmscriptenModuleOptions } from './retroarch-emscripten'
 
 type MaybePromise<T> = Promise<T> | T
 
-export type NostalgistOptionsFile = { fileContent: Blob; fileName: string } | File | string
+export type NostalgistOptionsFile = { fileContent: Blob; fileName: string } | File | string | Blob
 type NostalgistOptionsFiles = NostalgistOptionsFile | NostalgistOptionsFile[]
 
 export interface NostalgistCoreDict {

--- a/src/types/nostalgist-options.ts
+++ b/src/types/nostalgist-options.ts
@@ -4,7 +4,7 @@ import type { RetroArchEmscriptenModuleOptions } from './retroarch-emscripten'
 
 type MaybePromise<T> = Promise<T> | T
 
-export type NostalgistOptionsFile = { fileContent: Blob; fileName: string } | File | string | Blob
+export type NostalgistOptionsFile = { fileContent: Blob; fileName: string } | Blob | string
 type NostalgistOptionsFiles = NostalgistOptionsFile | NostalgistOptionsFile[]
 
 export interface NostalgistCoreDict {


### PR DESCRIPTION
Added the "Blob" type to the "rom" argument of the "launch" method since it accepts it. Also added to the docs

![image](https://github.com/user-attachments/assets/c4f80a4f-7e9a-4fc0-966e-c3e5e9cdc036)

```
          const romData = await unZipFile(gameRom) // Here I convert a rom to a Blob
          const gameProvider = await Nostalgist.launch({
            element: canvas,
            rom: romData,
            core: core,
          })
          console.log("Rom Blob: ", romData instanceof Blob)
          console.log("game: ", romData)
          console.log("Nostalgist rom: ", gameProvider.getOptions().rom)
          gameInstance.current = gameProvider
```
