### PR TITLE
docs: Fix launch args for custom cores

### DIFF
--- a/docs/src/content/docs/apis/launch.md
+++ b/docs/src/content/docs/apis/launch.md
@@ -92,7 +92,7 @@ const nostalgist = await Nostalgist.launch({
     ```js
     await Nostalgist.launch({
       core: {
-        core: 'https://example.com/cores/snes9x.js',
+        js: 'https://example.com/cores/snes9x.js',
         name: 'snes9x',
         wasm: 'https://example.com/cores/snes9x.wasm',
       },


### PR DESCRIPTION
I tried building a demo with a custom core based on the snippet from the docs, and only discovered the typo (the inner `core` should say `js`) after spending some time in the debugger.