### PR TITLE
Threaded core fixes part 2

### DIFF
--- a/src/classes/emulator.ts
+++ b/src/classes/emulator.ts
@@ -245,7 +245,16 @@ export class Emulator {
   resize({ height, width }: { height: number; width: number }) {
     const { Module } = this.getEmscripten()
     if (typeof width === 'number' && typeof height === 'number') {
-      Module.setCanvasSize(width, height)
+      try {
+        Module.setCanvasSize(width, height)
+      } catch (error) {
+        if (error instanceof DOMException) {
+          Module.canvas.setAttribute('width', width.toString())
+          Module.canvas.setAttribute('height', height.toString())
+        } else {
+          throw error
+        }
+      }
     }
   }
 

--- a/src/libs/utils.ts
+++ b/src/libs/utils.ts
@@ -96,16 +96,28 @@ async function patchCoreJs({ js, name }: { js: ResolvableFile; name: string }) {
          }
       }`
   } else if (isEsmScript(jsContent)) {
-    jsContent = `${jsContent.replace('var setImmediate', '').replace(
-      'readyPromiseResolve(Module)',
-      `readyPromiseResolve({
-        AL: typeof AL === 'undefined' ? null: AL,
-        Browser: typeof Browser === 'undefined' ? null: Browser,
-        JSEvents,
-        Module,
-        exit: _emscripten_force_exit
-      })`,
-    )};
+    jsContent = `${jsContent
+      .replace('var setImmediate', '')
+      .replace(
+        'readyPromiseResolve(Module)',
+        `readyPromiseResolve({
+          AL: typeof AL === 'undefined' ? null: AL,
+          Browser: typeof Browser === 'undefined' ? null: Browser,
+          JSEvents,
+          Module,
+          exit: _emscripten_force_exit
+        })`,
+      )
+      .replace(
+        'return moduleRtn;',
+        `return moduleRtn.then((Module) => ({
+          AL: typeof AL === 'undefined' ? null: AL,
+          Browser: typeof Browser === 'undefined' ? null: Browser,
+          JSEvents,
+          exit: _emscripten_force_exit,
+          ...Module,
+        }));`,
+      )};
     export function getEmscripten({ Module }) {
       const fnA = (typeof libretro_${name} === "function") ? libretro_${name} : null;
       const fnB = (typeof ${name} === "function") ? ${name} : null;


### PR DESCRIPTION
* Calling `Module.setCanvasSize()` doesn't work for threaded cores. Instead, the width and height attributes should be manually set on the canvas element.
* The `patchCoreJs()` function also doesn't work properly for threaded cores currently.

If you need a threaded core built with a sufficiently recent version of RetroArch to test with, you can try using the "mkxp-z_libretro.wasm" artifact from https://github.com/white-axe/mkxp-z-libretro-emscripten/actions/runs/21577141422 as the core along with the "star-stealing-prince.mkxpz" artifact as the ROM.