### PR TITLE
feat: Cache keyboard codes to avoid repeated INI parsing

### DIFF
--- a/src/classes/emulator.ts
+++ b/src/classes/emulator.ts
@@ -48,6 +48,7 @@ export class Emulator {
   private blobUrlJs: string | undefined
   private blobUrlWasm: string | undefined
 
+  private cachedKeyboardCodes: Map<string, string> | null = null
   private canvasInitialSize = { height: 0, width: 0 }
   private emscripten: EmulatorEmscripten | undefined
   private eventListeners: Record<EmulatorEvent, ((...args: unknown[]) => unknown)[]> = {
@@ -57,7 +58,7 @@ export class Emulator {
   private fileSystem: EmulatorFileSystem | undefined
   private gameStatus: GameStatus = 'initial'
   private globalDOMEventListeners = new Map<EventTarget, Record<string, EventListenerOrEventListenerObject>>()
-  private cachedKeyboardCodes: Map<string, string> | null = null
+
   private messageQueue: [Uint8Array, number][] = []
 
   private options: EmulatorOptions

--- a/src/classes/emulator.ts
+++ b/src/classes/emulator.ts
@@ -57,8 +57,8 @@ export class Emulator {
   private fileSystem: EmulatorFileSystem | undefined
   private gameStatus: GameStatus = 'initial'
   private globalDOMEventListeners = new Map<EventTarget, Record<string, EventListenerOrEventListenerObject>>()
-  private messageQueue: [Uint8Array, number][] = []
   private cachedKeyboardCodes: Map<string, string> | null = null
+  private messageQueue: [Uint8Array, number][] = []
 
   private options: EmulatorOptions
 
@@ -123,7 +123,7 @@ export class Emulator {
     const { exit, JSEvents } = this.getEmscripten()
     try {
       exit(statusCode)
-    } catch { }
+    } catch {}
     JSEvents.removeAllEventListeners()
     this.removeGlobalDOMEventListeners()
     if (this.blobUrlWasm !== undefined) {
@@ -337,7 +337,7 @@ export class Emulator {
     try {
       this.fs.unlink(this.stateFilePath)
       this.fs.unlink(this.stateThumbnailFilePath)
-    } catch { }
+    } catch {}
   }
 
   private fireKeyboardEvent(type: 'keydown' | 'keyup', code: string) {
@@ -346,7 +346,7 @@ export class Emulator {
       if (eventTypeString === type) {
         try {
           eventListenerFunc({ code, target: this.options.element })
-        } catch { }
+        } catch {}
       }
     }
   }
@@ -499,12 +499,12 @@ export class Emulator {
     const blobJs = (() => {
       try {
         return js.getBlob()
-      } catch { }
+      } catch {}
     })()
     const blobWasm = (() => {
       try {
         return wasm.getBlob()
-      } catch { }
+      } catch {}
     })()
     if (blobJs !== undefined && this.blobUrlJs === undefined) {
       this.blobUrlJs = URL.createObjectURL(blobJs)


### PR DESCRIPTION
Currently, every call to pressDown/pressUp triggers getCurrentRetroarchConfig() which reads and parses the INI config file. This causes noticeable input lag on mobile devices.

This PR caches all input_player* mappings in a Map on first access, making subsequent lookups O(1) instead of re-parsing the entire config.