### PR TITLE
Handle missing core information

### DIFF
--- a/src/classes/emulator.ts
+++ b/src/classes/emulator.ts
@@ -66,7 +66,7 @@ export class Emulator {
 
   private get coreFullName() {
     const { core } = this.options
-    const coreFullName = coreInfoMap[core.name].corename || core.name
+    const coreFullName = coreInfoMap[core.name]?.corename || core.name
     if (!coreFullName) {
       throw new Error(`invalid core name: ${core.name}`)
     }


### PR DESCRIPTION
- Improved error handling in the `coreFullName` getter by using optional chaining (`?.`) to safely access the `corename` property from `coreInfoMap`, preventing a possible crash if the core is not present in the map. So we can build actually custom core like `mgba_dual` likely